### PR TITLE
Release mulea 1.1.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: mulea
 Type: Package
 Title: Enrichment Analysis using Multiple Ontologies and False Discovery Rate
 Version: 1.1.0
-Date: 2024-08-27
+Date: 2024-09-24
 Authors@R: c(
     person("Cezary", "Turek", role =  "aut",
         comment = c(ORCID = "0000-0002-1445-5378")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mulea
 Type: Package
 Title: Enrichment Analysis using Multiple Ontologies and False Discovery Rate
-Version: 1.0.2
+Version: 1.1.0
 Date: 2024-08-27
 Authors@R: c(
     person("Cezary", "Turek", role =  "aut",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,13 @@
-# # mulea 1.0.2
+# mulea 1.1.0
+
+## Minor Improvements
 
 - Random seed argument was introduced to the ora function.
+- Range in internal function `addExtraParamsToPlt()` was updated from 0 to 0.2.
 
 # mulea 1.0.1
 
-## BUGS
+## Bug Fixes
 
 - CRAN check results indicated some OS dependent behaviour. This is now fixed.
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -48,7 +48,7 @@ if (!require("BiocManager", quietly = TRUE))
 BiocManager::install("fgsea")
 ```
 
-To install `mulea` from [CRAN](https://cran.rstudio.com/web/packages/mulea/index.html):
+To install `mulea` from [CRAN](https://cran.r-project.org/package=mulea):
 
 ```{r 'install2', eval=FALSE, message=FALSE, warning=FALSE}
 install.packages("mulea")

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ BiocManager::install("fgsea")
 ```
 
 To install `mulea` from
-[CRAN](https://cran.rstudio.com/web/packages/mulea/index.html):
+[CRAN](https://cran.r-project.org/package=mulea):
 
 ``` r
 install.packages("mulea")

--- a/vignettes/mulea.Rmd
+++ b/vignettes/mulea.Rmd
@@ -58,7 +58,7 @@ if (!require("BiocManager", quietly = TRUE))
 BiocManager::install("fgsea")
 ```
 
-To install `mulea` from [CRAN](https://cran.rstudio.com/web/packages/mulea/index.html):
+To install `mulea` from [CRAN](https://cran.r-project.org/package=mulea):
 
 ```{r 'install2', eval=FALSE, message=FALSE, warning=FALSE}
 install.packages("mulea")

--- a/vignettes/mulea.Rmd
+++ b/vignettes/mulea.Rmd
@@ -387,7 +387,9 @@ BH_ora_model <- ora(gmt = tf_ontology_filtered,
                  # Background set variable
                  background_element_names = background_set, 
                  # p-value adjustment method
-                 p_value_adjustment_method = "BH") 
+                 p_value_adjustment_method = "BH",
+                 # Number of processor threads to use
+                 nthreads = 2) 
 
 # Running the ORA
 BH_results <- run_test(BH_ora_model)
@@ -399,7 +401,9 @@ Bonferroni_ora_model <- ora(gmt = tf_ontology_filtered,
                             # Background set variable
                             background_element_names = background_set, 
                             # p-value adjustment method
-                            p_value_adjustment_method = "bonferroni") 
+                            p_value_adjustment_method = "bonferroni",
+                            # Number of processor threads to use
+                            nthreads = 2) 
 
 # Running the ORA
 Bonferroni_results <- run_test(Bonferroni_ora_model)


### PR DESCRIPTION
Related to issue #38.

This PR limits the number of threads in the vignette to align with CRAN policy (1-2 threads), updates some URLs to CRAN canonical form and performs standard updates to prepare the package for the next release.