### PR TITLE
Fix R CMD check on Windows: propagate .libPaths() to PSOCK eFDR workers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mulea
 Type: Package
 Title: Enrichment Analysis Using Multiple Ontologies and False Discovery Rate
-Version: 1.1.1
+Version: 1.1.2
 Authors@R: c(
     person("Cezary", "Turek", role =  "aut",
         comment = c(ORCID = "0000-0002-1445-5378")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# mulea 1.1.2
+
+## Bug Fixes
+
+- The resampling eFDR's parallel backend now propagates the host's library paths to
+  the PSOCK worker processes before loading the package. This fixes vignette
+  re-building under `R CMD check` on Windows, which failed with "there is no package
+  called 'mulea'" because the workers could not locate the package in the temporary
+  `*.Rcheck` library.
+
 # mulea 1.1.1
 
 - Updated citation to the BMC Bioinformatics article.

--- a/R/set-based-enrichment-test.r
+++ b/R/set-based-enrichment-test.r
@@ -66,9 +66,17 @@ do_the_simulation <- function(list_of_all_genes, pool, select,DB, steps,
             sep = "\\")
             cl <- makeCluster(spec=nthread, type="PSOCK", outfile=cl_outfile)
         } else { cl <- makeCluster(spec = nthread, type = "PSOCK")}
+        # Propagate the host's library paths to the PSOCK workers before loading
+        # the package. PSOCK workers are fresh R sessions that do not inherit the
+        # parent's .libPaths(); without this, library("mulea") fails on them when
+        # the package lives outside the default library tree -- e.g. the temporary
+        # *.Rcheck library during R CMD check (notably on Windows), which aborts
+        # vignette re-building with "there is no package called 'mulea'".
+        worker_libpaths <- .libPaths()
         clusterExport(cl, c("DB","list_of_all_genes", "pool", "select",
-            "seeds_per_thread", "steps_per_thread"), envir = environment())
-        clusterEvalQ(cl, library("mulea"))
+            "seeds_per_thread", "steps_per_thread", "worker_libpaths"),
+            envir = environment())
+        clusterEvalQ(cl, { .libPaths(worker_libpaths); library("mulea") })
         result_of_paralel <- clusterApplyLB(cl = cl, seq_len(nthread), 
             function(idx) {simulation_result_tbl <- tryCatch(
                 enrichment_test_simulation(DB, list_of_all_genes, pool, 


### PR DESCRIPTION
## Problem

`set_based_enrichment_test()` runs the resampling eFDR on a PSOCK cluster and loads the package on
each worker with `clusterEvalQ(cl, library("mulea"))`. PSOCK workers are **fresh R sessions that do
not inherit the parent's `.libPaths()`**. When `mulea` is not on a worker's default library tree —
most notably the temporary `*.Rcheck` library used during `R CMD check` — `library("mulea")` fails
on the workers and the whole call aborts.

In practice this breaks `R CMD check` on **Windows**, where re-building the vignette (`mulea.Rmd`,
which runs eFDR with `nthreads = 2`) fails with:

```
--- re-building 'mulea.Rmd' using rmarkdown
Error in checkForRemoteErrors(...) :
  2 nodes produced errors; first error: there is no package called 'mulea'
--- failed re-building 'mulea.Rmd'
Error: Vignette re-building failed.
```

Unix workers happen to pick up the check library via the inherited `R_LIBS` environment, so the
failure is Windows-specific, but the underlying cluster setup is fragile on every platform.

## Fix

Capture the host's library paths, export them to the workers, and set them **before** loading the
package:

```r
worker_libpaths <- .libPaths()
clusterExport(cl, c(..., "worker_libpaths"), envir = environment())
clusterEvalQ(cl, { .libPaths(worker_libpaths); library("mulea") })
```

One file changed (`R/set-based-enrichment-test.r`), plus a `NEWS.md` entry and a patch version bump.

## Why it is safe

The change only affects **how the workers locate the package**. It does not touch the RNG, the
per-thread seeding (`seeds_per_thread`), the C++ simulation, or any arithmetic, so eFDR results are
unchanged. In normal installed use the workers already resolve `library("mulea")` via the default
library path, so this is purely a check/build-robustness fix with no behavioural change for users.

## Verification

- On an installed build, `ora(..., p_value_adjustment_method = "eFDR", nthreads = 2)` runs without
  error and its `p_value` column is byte-identical to the serial (`nthreads = 1`) path.
- The full `R-CMD-check` matrix now passes on **windows-latest** (previously failing on the vignette
  rebuild), alongside ubuntu-latest release/devel and macOS.
